### PR TITLE
Move authentication message to event_ready()

### DIFF
--- a/twitchio/base.py
+++ b/twitchio/base.py
@@ -216,7 +216,6 @@ class BaseConnection:
 
         if code == 376:
             await self.event_ready()
-            print('\n\033[92mSuccessful Authentication: {0._host}:{0._port}\033[0m\n'.format(self))
             # todo logging
 
         elif data == ':tmi.twitch.tv NOTICE * :Login authentication failed':
@@ -333,7 +332,8 @@ class BaseConnection:
         Event called when the :class:`.Client` has successfully authenticated
         on the Twitch server.
         """
-        pass
+
+        print('\033[92mSuccessful Authentication: {0._host}:{0._port}\033[0m'.format(self))
 
     async def event_error(self, error_name, *args, **kwargs):
         """|coro|


### PR DESCRIPTION
Move successful authentication message to inside `event_ready()` function. Additionally, remove redundant blank lines around this message. This allows users to easily remove or change this message if they wish through `async def event_ready(self)` instead of having an additional hardcoded message in their output with redundant whitespace. 