### PR TITLE
Fix import errors in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,118 @@
-# Ignore logs
-*.log
+## Ignore editors
 
-# Ignore IntelliJ files
 .idea/
+
+
+## Ignore Python - https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -1,4 +1,4 @@
-from twitchio import commands
+from twitchio.ext import commands
 
 # api token can be passed as test if not needed.
 # Channels is the initial channels to join, this could be a list, tuple or callable

--- a/examples/discord_integration.py
+++ b/examples/discord_integration.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from twitchio import commands as tcommands
+from twitchio.ext import commands as tcommands
 
 
 class DiscordCog(tcommands.TwitchBot):

--- a/examples/subclass_bot.py
+++ b/examples/subclass_bot.py
@@ -1,4 +1,4 @@
-from twitchio import commands
+from twitchio.ext import commands
 
 
 class Bot(commands.TwitchBot):


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes the import errors which were introduced in 44d967965f2becb6a8062960ad9d35c85c88e20d and thus closes #10.

* **What is the current behavior?** (You can also link to an open issue here)

Running the examples fails, as the `commands` module is now a namespace package.

* **What is the new behavior (if this is a feature change)?**

Running the examples works again. I haven't tested further than attempting to log in though, as I'm not familiar with this part of the API yet.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

🐱