### PR TITLE
Better pagination and ratelimit handling for Helix APIs

### DIFF
--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -159,26 +159,3 @@ class TwitchClient:
         """
 
         return await self.http.get_top_games(limit=limit)
-
-    async def get_chatters(self, channel: str):
-        """|coro|
-
-        Method which retrieves the currently active chatters on the given stream.
-
-        Parameters
-        ------------
-        channel: str [Required]
-            The channel name to retrieve data for.
-
-        Returns
-        ---------
-        dict:
-            Dict containing active chatter data.
-
-        Raises
-        --------
-        TwitchHTTPException
-            Bad request while fetching stream chatters.
-        """
-
-        raise NotImplementedError

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -1,13 +1,13 @@
 import asyncio
 from typing import Union
-from twitchio.http import HTTPSession
+from twitchio.http import HelixHTTPSession
 
 
 class TwitchClient:
 
     def __init__(self, *, loop=None, client_id=None, **kwargs):
         loop = loop or asyncio.get_event_loop()
-        self.http = HTTPSession(loop=loop, client_id=client_id)
+        self.http = HelixHTTPSession(loop=loop, client_id=client_id)
 
     async def get_users(self, *users: Union[str, int]):
         """|coro|
@@ -34,7 +34,8 @@ class TwitchClient:
         .. note::
             This method accepts both user ids or names, or a combination of both. Multiple names/ids may be passed.
         """
-        return await self.http._get_users(*users)
+
+        return await self.http.get_users(*users)
 
     async def get_stream_by_name(self, channel: str):
         """|coro|
@@ -56,7 +57,9 @@ class TwitchClient:
         TwitchHTTPException
             Bad request while fetching stream.
         """
-        return await self.http._get_stream_by_name(channel)
+
+        data = await self.http.get_streams(channels=[channel])
+        return data[0]
 
     async def get_stream_by_id(self, channel: int):
         """|coro|
@@ -78,17 +81,25 @@ class TwitchClient:
         TwitchHTTPException
             Bad request while fetching stream.
         """
-        return await self.http._get_stream_by_id(channel)
 
-    async def get_streams(self, *channels: Union[int, str]):
+        data = await self.http.get_streams(channels=[channel])
+        return data[0]
+
+    async def get_streams(self, *, game_id=None, language=None, channels=None, limit=None):
         """|coro|
 
         Method which retrieves multiple stream information on the given channels, provided they are active (Live).
 
         Parameters
         ------------
-        \*channels: Union[int, str]
+        game_id: Optional[int]
+            The game to filter streams for.
+        language: Optional[str]
+            The language to filter streams for.
+        channels: Union[int, str]
             The channels in id or name form, to retrieve information for.
+        limit: Optional[int]
+            Maximum number of results to return.
 
         Returns
         ---------
@@ -100,7 +111,8 @@ class TwitchClient:
         TwitchHTTPException
             Bad request while fetching streams.
         """
-        return await self.http._get_streams(*channels)
+
+        return await self.http.get_streams(game_id=game_id, language=language, channels=channels, limit=limit)
 
     async def get_games(self, *games: Union[str, int]):
         """|coro|
@@ -122,7 +134,31 @@ class TwitchClient:
         TwitchHTTPException
             Bad request while fetching games.
         """
-        return await self.http._get_games(*games)
+
+        return await self.http.get_games(*games)
+
+    async def get_top_games(self, limit=None):
+        """|coro|
+
+        Retrieves the top games currently being played on Twitch.
+
+        Parameters
+        ------------
+        limit: Optional[int]
+            Maximum amount of results to fetch.
+
+        Returns
+        ---------
+        list:
+            List containing game information. Could be None if no games matched.
+
+        Raises
+        --------
+        TwitchHTTPException
+            Bad request while fetching games.
+        """
+
+        return await self.http.get_top_games(limit=limit)
 
     async def get_chatters(self, channel: str):
         """|coro|
@@ -144,4 +180,5 @@ class TwitchClient:
         TwitchHTTPException
             Bad request while fetching stream chatters.
         """
-        return await self.http._get_chatters(channel)
+
+        raise NotImplementedError

--- a/twitchio/dataclasses.py
+++ b/twitchio/dataclasses.py
@@ -99,7 +99,9 @@ class Channel(Messageable):
         TwitchHTTPException
             Bad request while fetching streams.
         """
-        return await self._http._get_stream_by_name(self.name)
+
+        data = await self._http.get_streams(channels=[self.name])
+        return data[0]
 
     async def get_chatters(self):
         """|coro|
@@ -116,7 +118,8 @@ class Channel(Messageable):
         TwitchHTTPException
             Bad request while fetching stream chatters.
         """
-        return await self._http._get_chatters(self.name)
+
+        raise NotImplementedError
 
 
 class User(Messageable):

--- a/twitchio/dataclasses.py
+++ b/twitchio/dataclasses.py
@@ -103,24 +103,6 @@ class Channel(Messageable):
         data = await self._http.get_streams(channels=[self.name])
         return data[0]
 
-    async def get_chatters(self):
-        """|coro|
-
-        Method which retrieves the currently active chatters on the given stream.
-
-        Returns
-        ---------
-        dict:
-            Dict containing active chatter data.
-
-        Raises
-        --------
-        TwitchHTTPException
-            Bad request while fetching stream chatters.
-        """
-
-        raise NotImplementedError
-
 
 class User(Messageable):
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -148,7 +148,6 @@ class HelixHTTPSession:
         else:
             params = []
 
-        print(params)
         if game_id is not None:
             params.append(('game_id', str(game_id)))
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -51,7 +51,6 @@ class HelixHTTPSession:
         url = f'{self.BASE}{url}'
 
         cursor = None
-        can_paginate = True
 
         def reached_limit():
             return limit and len(data) >= limit
@@ -63,7 +62,7 @@ class HelixHTTPSession:
             to_get = limit - len(data)
             return str(to_get) if to_get < 100 else '100'
 
-        while can_paginate and not reached_limit():
+        while not reached_limit():
             if cursor is not None:
                 params.append(('after', cursor))
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -107,7 +107,7 @@ class HelixHTTPSession:
                     reason = 'Ratelimit Reached'
                     continue  # the Bucket will handle waiting
 
-                raise TwitchHTTPException(f'Failed to fulfil request ({resp.status}).', reason)
+                raise TwitchHTTPException(f'Failed to fulfil request ({resp.status}).', resp.reason)
 
         raise TwitchHTTPException('Failed to reach Twitch API', reason)
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -19,8 +19,6 @@ class Bucket:
         return self.tokens == self.LIMIT
 
     def update(self, *, reset=None, remaining=None):
-        now = time.time()
-
         if reset:
             self.reset = int(reset)
 
@@ -163,11 +161,3 @@ class HelixHTTPSession:
 
     async def get_top_games(self, limit=None):
         return await self.get('/games/top', limit=limit)
-
-# todo: reimplement this separately
-"""
-    async def get_chatters(self, channel: str):
-        channel = channel.lower()
-        url = f'http://tmi.twitch.tv/group/user/{channel}/chatters'
-        return await self._get(url)
-"""

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -95,19 +95,19 @@ class HelixHTTPSession:
                     await asyncio.sleep(2 ** attempt + 1)
                     continue
 
-                data = await resp.json()
-
                 reset = resp.headers.get('Ratelimit-Reset')
                 remaining = resp.headers.get('Ratelimit-Remaining')
 
                 self._bucket.update(reset=reset, remaining=remaining)
 
                 if 200 <= resp.status < 300:
-                    return data
+                    return await resp.json()
 
                 if resp.status == 429:
                     reason = 'Ratelimit Reached'
                     continue  # the Bucket will handle waiting
+
+                raise TwitchHTTPException(f'Failed to fulfil request ({resp.status}).', reason)
 
         raise TwitchHTTPException('Failed to reach Twitch API', reason)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [x] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR reworks the HTTP class to handle pagination better by requesting up to 100 results at a time and reworks ratelimit handling to use the headers and a local bucket.

* **What is the current behavior?** (You can also link to an open issue here)

Currently only 20 items are requested per page and running into ratelimits just throws an error, in which case the user has to retry.

* **What is the new behavior (if this is a feature change)?**

Up to 100 items are requested at once and ratelimits are handled internally with up to five retries.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, the `get_chatters` method has been removed.

* **Other information**:

boop