### PR TITLE
Fix Bucket implementation and false attempt to paginate

### DIFF
--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -86,7 +86,11 @@ class HelixHTTPSession:
                 params.pop()
 
             data += body['data']
-            cursor = body['pagination'].get('cursor', None)
+
+            try:
+                cursor = body['pagination'].get('cursor', None)
+            except KeyError:
+                break
 
         return data
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -12,25 +12,35 @@ class Bucket:
 
     def __init__(self):
         self.tokens = 0
-        self.reset = time.time() + 60
+        self._reset = time.time() + 60
 
     @property
     def limited(self):
         return self.tokens == self.LIMIT
 
+    def reset(self):
+        self.tokens = 0
+        self._reset = time.time() + 60
+
     def update(self, *, reset=None, remaining=None):
+        now = time.time()
+
+        if self._reset <= now:
+            self.reset()
+
         if reset:
-            self.reset = int(reset)
+            self._reset = int(reset)
 
         if remaining:
             self.tokens = self.LIMIT - int(remaining)
         else:
-            self.tokens -= 1
+            self.tokens += 1
 
     async def wait_reset(self):
         now = time.time()
 
-        await asyncio.sleep(self.reset - now)
+        await asyncio.sleep(self._reset - now)
+        self.reset()
 
 
 class HelixHTTPSession:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests have been conducted on the PR
- [x] Docs have been added / updated


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Buckets now properly reset and add tokens
- Attempts to paginate where no pagination is possible no longer break

* **What is the current behavior?** (You can also link to an open issue here)

- If no ratelimit headers are returned (which they are - but we still implement this locally) the bucket would continue to subscract tokens and never make the library wait.
- The pagination would throw a KeyError when using `get_games`.

* **What is the new behavior (if this is a feature change)?**

The library throws fewer errors.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

beep